### PR TITLE
Fix spacing for flattened template output

### DIFF
--- a/.changeset/lucky-pillows-fail.md
+++ b/.changeset/lucky-pillows-fail.md
@@ -1,0 +1,5 @@
+---
+"@osrs-wiki/mediawiki-builder": patch
+---
+
+Fix spacing for flattened template output

--- a/src/contents/__tests__/__snapshots__/template.test.ts.snap
+++ b/src/contents/__tests__/__snapshots__/template.test.ts.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MediaWikiTemplate it should render expanded with 4 or more params 1`] = `
+"{{test
+|one = one
+|two = two
+|three = three
+|four = four
+}}
+"
+`;
+
+exports[`MediaWikiTemplate it should render flattened with less than 4 params 1`] = `
+"{{test|one=one|two=two|three=three}}
+"
+`;

--- a/src/contents/__tests__/template.test.ts
+++ b/src/contents/__tests__/template.test.ts
@@ -1,0 +1,22 @@
+import { MediaWikiTemplate } from "../template";
+
+describe("MediaWikiTemplate", () => {
+  test("it should render flattened with less than 4 params", () => {
+    const template = new MediaWikiTemplate("test");
+    template.add("one", "one");
+    template.add("two", "two");
+    template.add("three", "three");
+
+    expect(template.build()).toMatchSnapshot();
+  });
+
+  test("it should render expanded with 4 or more params", () => {
+    const template = new MediaWikiTemplate("test");
+    template.add("one", "one");
+    template.add("two", "two");
+    template.add("three", "three");
+    template.add("four", "four");
+
+    expect(template.build()).toMatchSnapshot();
+  });
+});

--- a/src/contents/template.ts
+++ b/src/contents/template.ts
@@ -17,13 +17,14 @@ export class MediaWikiTemplate extends MediaWikiContent {
   }
 
   build() {
+    const expanded = this.params.length > 3;
     const params = this.params.reduce(
       (allParams, param) =>
         `${allParams}${this.params.length > 3 ? "\n" : ""}|${
-          param.key ? param.key + " = " : ""
+          param.key ? param.key + (expanded ? " = " : "=") : ""
         }${param.value}`,
       ""
     );
-    return `{{${this.name}${params}${this.params.length > 3 ? "\n" : ""}}}\n`;
+    return `{{${this.name}${params}${expanded ? "\n" : ""}}}\n`;
   }
 }


### PR DESCRIPTION
When a template renders flattened it should use "=" instead of " = " for params.