### PR TITLE
Add collapse option to MediaWikiHTML

### DIFF
--- a/.changeset/ninety-pumas-end.md
+++ b/.changeset/ninety-pumas-end.md
@@ -1,0 +1,5 @@
+---
+"@osrs-wiki/mediawiki-builder": minor
+---
+
+Add collapse option to MediaWikiHTML

--- a/src/contents/__tests__/html.test.ts
+++ b/src/contents/__tests__/html.test.ts
@@ -17,4 +17,14 @@ describe("MediaWikiHTML", () => {
       "<center param=\"123\">\ntest'''test2'''\n</center>\n"
     );
   });
+
+  test("it should build correctly with collapsed option", () => {
+    const result = new MediaWikiHTML(
+      "center",
+      [new MediaWikiText("test")],
+      {},
+      { collapsed: true }
+    );
+    expect(result.build()).toBe("<center>test</center>");
+  });
 });

--- a/src/contents/html.ts
+++ b/src/contents/html.ts
@@ -1,17 +1,24 @@
 import MediaWikiContent from "../content";
 
+export type MediaWikiHTMLOptions = {
+  collapsed?: boolean;
+};
+
 export class MediaWikiHTML extends MediaWikiContent {
   attributes?: { [key: string]: string };
   tag: string;
+  options?: MediaWikiHTMLOptions;
 
   constructor(
     tag: string,
     children: MediaWikiContent[],
-    attributes?: { [key: string]: string }
+    attributes?: { [key: string]: string },
+    options?: MediaWikiHTMLOptions
   ) {
     super(children);
     this.tag = tag;
     this.attributes = attributes;
+    this.options = options;
   }
 
   build() {
@@ -21,6 +28,8 @@ export class MediaWikiHTML extends MediaWikiContent {
             (key) => ` ${key}=\"${this.attributes?.[key]}\"`
           )
         : ""
-    }>\n${this.buildChildren()}\n</${this.tag}>\n`;
+    }>${this.options?.collapsed ? "" : "\n"}${this.buildChildren()}${
+      this.options?.collapsed ? "" : "\n"
+    }</${this.tag}>${this.options?.collapsed ? "" : "\n"}`;
   }
 }


### PR DESCRIPTION
- Add `MediaWikiHTMLOptions` as a constructor param to `MediaWikiHTML`
- Add `collapse` option to `MediaWikiHTML` to prevent line breaks
- Update tests