### PR TITLE
Trim MediaWikiHeader content

### DIFF
--- a/.changeset/fast-kids-move.md
+++ b/.changeset/fast-kids-move.md
@@ -1,0 +1,5 @@
+---
+"@osrs-wiki/mediawiki-builder": patch
+---
+
+Trim headers

--- a/src/contents/__tests__/header.test.ts
+++ b/src/contents/__tests__/header.test.ts
@@ -3,7 +3,7 @@ import { MediaWikiText } from "../text";
 
 describe("MediaWikiHeader", () => {
   test("it should build correctly with a string value", () => {
-    const header = new MediaWikiHeader("Test", 2);
+    const header = new MediaWikiHeader(" Test ", 2);
     expect(header.build()).toBe("==Test==");
   });
 
@@ -20,7 +20,7 @@ describe("MediaWikiHeader", () => {
       [
         new MediaWikiText("Start "),
         new MediaWikiText("Test", { italics: true }),
-        new MediaWikiText(" End"),
+        new MediaWikiText(" End "),
       ],
       3
     );

--- a/src/contents/header.ts
+++ b/src/contents/header.ts
@@ -18,12 +18,14 @@ export class MediaWikiHeader extends MediaWikiContent {
   }
 
   build() {
-    let parsedValue;
+    let parsedValue = "";
     if (this.children) {
       parsedValue = this.buildChildren();
     } else if (this.value) {
-      parsedValue = this.value.trim();
+      parsedValue = this.value;
     }
-    return `${"=".repeat(this.level)}${parsedValue}${"=".repeat(this.level)}`;
+    return `${"=".repeat(this.level)}${parsedValue.trim()}${"=".repeat(
+      this.level
+    )}`;
   }
 }


### PR DESCRIPTION
Trim headers that are built from `MediaWikiContent`.