### PR TITLE
Add collapsed option to MediaWikiTemplate

### DIFF
--- a/.changeset/green-bats-develop.md
+++ b/.changeset/green-bats-develop.md
@@ -1,0 +1,5 @@
+---
+"@osrs-wiki/mediawiki-builder": minor
+---
+
+Add TemplateOptions to MediaWikiTemplate

--- a/src/contents/__tests__/__snapshots__/template.test.ts.snap
+++ b/src/contents/__tests__/__snapshots__/template.test.ts.snap
@@ -1,5 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`MediaWikiTemplate it should render collapsed with 4 or more params and collapsed option 1`] = `
+"{{test|one=one|two=two|three=three|four=four}}
+"
+`;
+
 exports[`MediaWikiTemplate it should render expanded with 4 or more params 1`] = `
 "{{test
 |one = one

--- a/src/contents/__tests__/template.test.ts
+++ b/src/contents/__tests__/template.test.ts
@@ -19,4 +19,14 @@ describe("MediaWikiTemplate", () => {
 
     expect(template.build()).toMatchSnapshot();
   });
+
+  test("it should render collapsed with 4 or more params and collapsed option", () => {
+    const template = new MediaWikiTemplate("test", { collapsed: true });
+    template.add("one", "one");
+    template.add("two", "two");
+    template.add("three", "three");
+    template.add("four", "four");
+
+    expect(template.build()).toMatchSnapshot();
+  });
 });

--- a/src/contents/template.ts
+++ b/src/contents/template.ts
@@ -2,14 +2,18 @@ import MediaWikiContent from "../content";
 
 export type TemplateParam = { key: string; value: string };
 
+export type TemplateOptions = { collapsed?: boolean };
+
 export class MediaWikiTemplate extends MediaWikiContent {
   name: string;
   params: TemplateParam[];
+  options?: TemplateOptions;
 
-  constructor(name: string) {
+  constructor(name: string, options?: TemplateOptions) {
     super();
     this.name = name;
     this.params = [];
+    this.options = options;
   }
 
   add(key: string, value: string) {
@@ -17,14 +21,14 @@ export class MediaWikiTemplate extends MediaWikiContent {
   }
 
   build() {
-    const expanded = this.params.length > 3;
+    const collapsed = this.options?.collapsed || this.params.length < 4;
     const params = this.params.reduce(
       (allParams, param) =>
-        `${allParams}${this.params.length > 3 ? "\n" : ""}|${
-          param.key ? param.key + (expanded ? " = " : "=") : ""
+        `${allParams}${collapsed ? "" : "\n"}|${
+          param.key ? param.key + (collapsed ? "=" : " = ") : ""
         }${param.value}`,
       ""
     );
-    return `{{${this.name}${params}${expanded ? "\n" : ""}}}\n`;
+    return `{{${this.name}${params}${collapsed ? "" : "\n"}}}\n`;
   }
 }

--- a/src/contents/templates/__tests__/__snapshots__/listen.test.ts.snap
+++ b/src/contents/templates/__tests__/__snapshots__/listen.test.ts.snap
@@ -4,6 +4,7 @@ exports[`ListenTemplate it should render with only a file 1`] = `
 MediaWikiTemplate {
   "children": undefined,
   "name": "Listen",
+  "options": undefined,
   "params": Array [
     Object {
       "key": "filename",
@@ -17,6 +18,7 @@ exports[`ListenTemplate it should render with options: {"align":"left","title":"
 MediaWikiTemplate {
   "children": undefined,
   "name": "Listen",
+  "options": undefined,
   "params": Array [
     Object {
       "key": "filename",
@@ -38,6 +40,7 @@ exports[`ListenTemplate it should render with options: {"align":"left"} 1`] = `
 MediaWikiTemplate {
   "children": undefined,
   "name": "Listen",
+  "options": undefined,
   "params": Array [
     Object {
       "key": "filename",
@@ -55,6 +58,7 @@ exports[`ListenTemplate it should render with options: {"title":"test title"} 1`
 MediaWikiTemplate {
   "children": undefined,
   "name": "Listen",
+  "options": undefined,
   "params": Array [
     Object {
       "key": "filename",

--- a/src/contents/templates/__tests__/__snapshots__/newsPoll.test.ts.snap
+++ b/src/contents/templates/__tests__/__snapshots__/newsPoll.test.ts.snap
@@ -4,6 +4,7 @@ exports[`NewsPollTemplate it should render with a number and question 1`] = `
 MediaWikiTemplate {
   "children": undefined,
   "name": "News Poll",
+  "options": undefined,
   "params": Array [
     Object {
       "key": "",
@@ -21,6 +22,7 @@ exports[`NewsPollTemplate it should render with only a question 1`] = `
 MediaWikiTemplate {
   "children": undefined,
   "name": "News Poll",
+  "options": undefined,
   "params": Array [
     Object {
       "key": "qtext",


### PR DESCRIPTION
Add `collapsed` option to `MediaWikiTemplate` to force collapsing.