### PR TITLE
Correctly build InfoBoxTemplate falsey values

### DIFF
--- a/.changeset/short-trainers-marry.md
+++ b/.changeset/short-trainers-marry.md
@@ -1,0 +1,5 @@
+---
+"@osrs-wiki/mediawiki-builder": patch
+---
+
+Correctly build InfoBoxTemplate falsey values

--- a/src/builder/content/contents/MediaWikiTemplate/templates/InfoboxTemplate/InfoboxTemplate.test.ts
+++ b/src/builder/content/contents/MediaWikiTemplate/templates/InfoboxTemplate/InfoboxTemplate.test.ts
@@ -6,4 +6,10 @@ describe("InfoboxTemplate", () => {
       "{{Infobox Test|test=test}}\n"
     );
   });
+
+  it("should build with falsey values", () => {
+    expect(new InfoboxTemplate("Test", { test: false }).build().build()).toBe(
+      "{{Infobox Test|test=No}}\n"
+    );
+  });
 });

--- a/src/builder/content/contents/MediaWikiTemplate/templates/InfoboxTemplate/InfoboxTemplate.ts
+++ b/src/builder/content/contents/MediaWikiTemplate/templates/InfoboxTemplate/InfoboxTemplate.ts
@@ -16,7 +16,7 @@ export class InfoboxTemplate<T> extends Template {
     const infoboxTemplate = new MediaWikiTemplate(this.name);
     Object.keys(this.params).forEach((key) => {
       const value = params[key as keyof T];
-      if (value) {
+      if (value !== undefined) {
         let parsedValue = "";
         if (typeof value === "boolean") {
           parsedValue = value ? "Yes" : "No";


### PR DESCRIPTION
`valuse=false` should not build as `value = No` in `InfoboxTemplate`.