### PR TITLE
feat: Add support for rendering MediaWikiContent array in InfoboxTemplate params

### DIFF
--- a/.changeset/short-ants-turn.md
+++ b/.changeset/short-ants-turn.md
@@ -1,0 +1,5 @@
+---
+"@osrs-wiki/mediawiki-builder": minor
+---
+
+Add support for rendering MediaWikiContent array in InfoboxTemplate params

--- a/src/builder/content/contents/MediaWikiTemplate/templates/InfoboxTemplate/InfoboxTemplate.test.ts
+++ b/src/builder/content/contents/MediaWikiTemplate/templates/InfoboxTemplate/InfoboxTemplate.test.ts
@@ -1,4 +1,5 @@
 import { InfoboxTemplate } from "./InfoboxTemplate";
+import { MediaWikiText } from "../../../MediaWikiText";
 
 describe("InfoboxTemplate", () => {
   it("should build with name and params", () => {
@@ -11,5 +12,21 @@ describe("InfoboxTemplate", () => {
     expect(new InfoboxTemplate("Test", { test: false }).build().build()).toBe(
       "{{Infobox Test|test=No}}\n"
     );
+  });
+
+  it("should build with MediaWikiContent values", () => {
+    const content = new InfoboxTemplate("Test", {
+      test: new MediaWikiText("MediaWikiContent"),
+    });
+    expect(content.build().build()).toBe(
+      "{{Infobox Test|test=MediaWikiContent}}\n"
+    );
+  });
+
+  it("should build with array values", () => {
+    const content = new InfoboxTemplate("Test", {
+      test: [new MediaWikiText("Item1"), new MediaWikiText("Item2")],
+    });
+    expect(content.build().build()).toBe("{{Infobox Test|test=Item1 Item2}}\n");
   });
 });

--- a/src/builder/content/contents/MediaWikiTemplate/templates/InfoboxTemplate/InfoboxTemplate.ts
+++ b/src/builder/content/contents/MediaWikiTemplate/templates/InfoboxTemplate/InfoboxTemplate.ts
@@ -23,7 +23,14 @@ export class InfoboxTemplate<T> extends Template {
         } else if (value instanceof MediaWikiContent) {
           parsedValue = value.build();
         } else if (Array.isArray(value)) {
-          parsedValue = value.filter((v) => v && v !== null).join(", ");
+          if (value.length > 0 && value[0] instanceof MediaWikiContent) {
+            parsedValue = value
+              .filter((v) => v && v !== null)
+              .map((v) => (v instanceof MediaWikiContent ? v.build() : `${v}`))
+              .join(" ");
+          } else {
+            parsedValue = value.filter((v) => v && v !== null).join(", ");
+          }
         } else if (value) {
           parsedValue = `${value}`;
         }

--- a/src/builder/content/contents/MediaWikiTemplate/templates/InfoboxTemplate/infoboxes/InfoboxItem.ts
+++ b/src/builder/content/contents/MediaWikiTemplate/templates/InfoboxTemplate/infoboxes/InfoboxItem.ts
@@ -1,3 +1,5 @@
+import MediaWikiContent from "../../../../../MediaWikiContent";
+import { MediaWikiBreak } from "../../../../MediaWikiBreak";
 import { MediaWikiDate } from "../../../../MediaWikiDate";
 import { MediaWikiFile } from "../../../../MediaWikiFile";
 import { MediaWikiLink } from "../../../../MediaWikiLink";
@@ -5,7 +7,7 @@ import { InfoboxNo } from "../InfoboxTemplate.types";
 
 export type InfoboxItem = {
   name: string;
-  image: MediaWikiFile;
+  image: MediaWikiFile | (MediaWikiFile | MediaWikiBreak)[];
   release: MediaWikiDate | "";
   update: string;
   removal?: MediaWikiDate;


### PR DESCRIPTION
Add support for rendering an array of `MediaWikiContent` in infobox params.