### PR TITLE
feat: Add support for rendering no children tags in MediaWikiHTML

### DIFF
--- a/.changeset/bright-rivers-know.md
+++ b/.changeset/bright-rivers-know.md
@@ -1,0 +1,5 @@
+---
+"@osrs-wiki/mediawiki-builder": minor
+---
+
+Add support for rendering no children tags in MediaWikiHTML

--- a/src/builder/content/contents/MediaWikiHTML/MediaWikiHTML.test.ts
+++ b/src/builder/content/contents/MediaWikiHTML/MediaWikiHTML.test.ts
@@ -27,4 +27,9 @@ describe("MediaWikiHTML", () => {
     );
     expect(result.build()).toBe("<center>test</center>");
   });
+
+  test("it should build correctly with empty children", () => {
+    const result = new MediaWikiHTML("br");
+    expect(result.build()).toBe("<br/>");
+  });
 });

--- a/src/builder/content/contents/MediaWikiHTML/MediaWikiHTML.ts
+++ b/src/builder/content/contents/MediaWikiHTML/MediaWikiHTML.ts
@@ -8,7 +8,7 @@ export class MediaWikiHTML extends MediaWikiContent {
 
   constructor(
     tag: string,
-    children: MediaWikiContent[],
+    children?: MediaWikiContent[],
     attributes?: { [key: string]: string },
     options?: MediaWikiHTMLOptions
   ) {
@@ -19,14 +19,19 @@ export class MediaWikiHTML extends MediaWikiContent {
   }
 
   build() {
-    return `<${this.tag}${
-      this.attributes
-        ? Object.keys(this.attributes).map(
-            (key) => ` ${key}=\"${this.attributes?.[key]}\"`
-          )
-        : ""
-    }>${this.options?.collapsed ? "" : "\n"}${this.buildChildren()}${
+    const attributes = this.attributes
+      ? Object.keys(this.attributes).map(
+          (key) => ` ${key}=\"${this.attributes?.[key]}\"`
+        )
+      : "";
+    const children = this.buildChildren();
+    if (children.length === 0) {
+      return `<${this.tag}${attributes}/>`;
+    }
+    return `<${this.tag}${attributes}>${
       this.options?.collapsed ? "" : "\n"
-    }</${this.tag}>${this.options?.collapsed ? "" : "\n"}`;
+    }${children}${this.options?.collapsed ? "" : "\n"}</${this.tag}>${
+      this.options?.collapsed ? "" : "\n"
+    }`;
   }
 }


### PR DESCRIPTION
Add support for rendering no children tags in MediaWikiHTML, such as `<br/>`.