### PR TITLE
fix: InfoboxTemplate 0 number value parsing

### DIFF
--- a/.changeset/hungry-boats-dance.md
+++ b/.changeset/hungry-boats-dance.md
@@ -1,0 +1,5 @@
+---
+"@osrs-wiki/mediawiki-builder": patch
+---
+
+Fix InfoboxTemplate number 0 parsing

--- a/src/builder/content/contents/MediaWikiTemplate/templates/InfoboxTemplate/InfoboxTemplate.test.ts
+++ b/src/builder/content/contents/MediaWikiTemplate/templates/InfoboxTemplate/InfoboxTemplate.test.ts
@@ -47,4 +47,11 @@ describe("InfoboxTemplate", () => {
       "{{Infobox Test|test=Item1, Item2, 3, 4}}\n"
     );
   });
+
+  it("should build with 0 number value", () => {
+    const content = new InfoboxTemplate("Test", {
+      test: 0,
+    });
+    expect(content.build().build()).toBe("{{Infobox Test|test=0}}\n");
+  });
 });

--- a/src/builder/content/contents/MediaWikiTemplate/templates/InfoboxTemplate/InfoboxTemplate.ts
+++ b/src/builder/content/contents/MediaWikiTemplate/templates/InfoboxTemplate/InfoboxTemplate.ts
@@ -33,7 +33,7 @@ export class InfoboxTemplate<T> extends Template {
               .map((v) => (v instanceof MediaWikiContent ? v.build() : `${v}`))
               .join(" ");
           }
-        } else if (value) {
+        } else if (value !== undefined && value !== null) {
           parsedValue = `${value}`;
         }
         infoboxTemplate.add(key, parsedValue);


### PR DESCRIPTION
Fix `InfoboxTemplate` building a param number value of `0`.