### PR TITLE
fix: Add safety filter to buildContents function to handle undefined and null elements

### DIFF
--- a/.changeset/fix-undefined-build-error.md
+++ b/.changeset/fix-undefined-build-error.md
@@ -1,0 +1,5 @@
+---
+"@osrs-wiki/mediawiki-builder": patch
+---
+
+Fix TypeError when building content arrays containing undefined elements by adding safety filter to buildContents function.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,271 @@
+# GitHub Copilot Instructions
+
+## Project Overview
+
+This is a TypeScript library for building MediaWiki content programmatically, specifically designed for the OSRS (Old School RuneScape) Wiki. The library provides a fluent API for creating MediaWiki markup (wikitext) through a builder pattern, with support for templates, tables, links, and other MediaWiki elements.
+
+## Code Style & Architecture
+
+### General Guidelines
+
+- Use TypeScript with strict typing enabled
+- Follow ESLint and Prettier configurations
+- Export all public APIs from appropriate index files
+- Prefer composition over inheritance for content types
+- Use abstract classes for base functionality
+- Follow builder pattern for the main API
+
+### File Organization
+
+- Main exports are in `src/index.ts`
+- Core builder logic is in `src/builder/`
+- Content types are organized in `src/builder/content/contents/`
+- Each content type has its own directory with:
+  - `index.ts` - Main export
+  - `[ContentType].ts` - Implementation
+  - `[ContentType].types.ts` - Type definitions
+  - `[ContentType].test.ts` - Unit tests
+- Transformers for post-processing are in `src/builder/transformer/`
+- Utility functions are in appropriate `*.utils.ts` files
+
+### Library Structure
+
+The library follows a hierarchical structure:
+
+```typescript
+MediaWikiBuilder
+├── content: MediaWikiContent[]     // Array of content elements
+├── transformers: MediaWikiTransformer[]  // Post-processing transformers
+├── addContent(content)             // Add single content element
+├── addContents(contents[])         // Add multiple content elements
+├── addTransformer(transformer)    // Add post-processor
+└── build()                        // Generate final wikitext
+```
+
+### Content Type Implementation
+
+When creating new content types:
+
+```typescript
+import MediaWikiContent from "../../MediaWikiContent";
+import { MediaWikiContents } from "../../MediaWikiContent.types";
+
+export class MediaWikiNewContent extends MediaWikiContent {
+  constructor(children?: MediaWikiContents) {
+    super(children);
+    // Initialize properties
+  }
+
+  build(): string {
+    // Return the MediaWiki markup
+    return "wikitext output";
+  }
+}
+```
+
+Key principles:
+- Extend `MediaWikiContent` abstract class
+- Implement required `build()` method that returns wikitext string
+- Support optional children content via constructor
+- Use `buildChildren()` helper for nested content
+- Export from the content type's `index.ts` file
+
+### Content Types Directory Structure
+
+Each content type should follow this structure:
+
+```
+MediaWikiContentType/
+├── index.ts                    # Export the content type
+├── MediaWikiContentType.ts     # Main implementation
+├── MediaWikiContentType.types.ts  # Type definitions
+└── MediaWikiContentType.test.ts   # Unit tests
+```
+
+### Type Definitions
+
+- Define types in separate `*.types.ts` files
+- Use descriptive type names with the content type prefix
+- Prefer `type` declarations over `interface` for consistency
+- Export types from the main content index for public APIs
+- Use union types for flexible parameter handling
+
+Example:
+```typescript
+// MediaWikiTemplate.types.ts
+export type MediaWikiTemplateParam = {
+  key?: string;
+  value: string;
+};
+
+export type MediaWikiTemplateOptions = {
+  collapsed?: boolean;
+};
+```
+
+### Testing Guidelines
+
+- Use Jest for unit testing
+- Test files should be co-located with source files
+- Use snapshot testing for `build()` output verification
+- Test both positive and edge cases
+- Mock dependencies when needed
+
+Example test structure:
+```typescript
+import { MediaWikiContentType } from "./MediaWikiContentType";
+
+describe("MediaWikiContentType", () => {
+  test("basic functionality", () => {
+    const content = new MediaWikiContentType("test");
+    expect(content.build()).toBe("expected wikitext");
+  });
+
+  test("with options", () => {
+    const content = new MediaWikiContentType("test", { option: true });
+    expect(content.build()).toMatchSnapshot();
+  });
+});
+```
+
+### Builder API Patterns
+
+The main `MediaWikiBuilder` class uses method chaining:
+
+```typescript
+import { MediaWikiBuilder, MediaWikiText, MediaWikiTemplate } from "@osrs-wiki/mediawiki-builder";
+
+const builder = new MediaWikiBuilder()
+  .addContent(new MediaWikiText("Introduction"))
+  .addContent(new MediaWikiTemplate("Infobox"))
+  .addContent(new MediaWikiText("Content"));
+
+const wikitext = builder.build();
+```
+
+### Content Composition
+
+Content can be nested and composed:
+
+```typescript
+// Content with children
+const header = new MediaWikiHeader("Title", [
+  new MediaWikiText("Subtitle text")
+]);
+
+// Content arrays
+const contents = [
+  new MediaWikiText("First paragraph"),
+  new MediaWikiText("Second paragraph")
+];
+```
+
+### MediaWiki Markup Generation
+
+When implementing `build()` methods:
+
+- Generate valid MediaWiki markup (wikitext)
+- Handle special characters and escaping appropriately
+- Use consistent formatting (spacing, line breaks)
+- Support both inline and block-level content
+- Consider collapsing/expanding for templates with many parameters
+
+Example markup patterns:
+```typescript
+// Template: {{Template|param=value}}
+// Link: [[Page|Display Text]]
+// External Link: [https://example.com Display Text]
+// Bold: '''text'''
+// Italic: ''text''
+// Header: == Level 2 Header ==
+```
+
+### Transformer Implementation
+
+For post-processing content:
+
+```typescript
+import MediaWikiTransformer from "../MediaWikiTransformer";
+import MediaWikiContent from "../content/MediaWikiContent";
+
+export class CustomTransformer extends MediaWikiTransformer {
+  transform(content: MediaWikiContent[]): MediaWikiContent[] {
+    // Apply transformations to content array
+    return content.map(item => /* transform logic */);
+  }
+}
+```
+
+## Dependencies & Build
+
+### Core Dependencies
+- **tslib**: TypeScript runtime helpers (production dependency)
+- **tsdx**: Build tooling for TypeScript libraries
+- **jest**: Testing framework
+- **eslint/prettier**: Code quality and formatting
+
+### Build Scripts
+- `yarn build`: Compile TypeScript to JavaScript
+- `yarn test`: Run Jest tests
+- `yarn lint`: Run ESLint
+- `yarn start`: Watch mode for development
+
+### Publishing
+- Uses changesets for version management
+- Supports canary releases for testing
+- Exports both CommonJS and ES modules
+- Includes TypeScript declarations
+
+## API Design Principles
+
+### Fluent Interface
+- Support method chaining where appropriate
+- Return `this` from builder methods
+- Make common operations simple and readable
+
+### Type Safety
+- Use strict TypeScript configuration
+- Provide comprehensive type definitions
+- Support IntelliSense for better developer experience
+
+### Extensibility
+- Abstract base classes for easy extension
+- Transformer pattern for post-processing
+- Plugin-like architecture for content types
+
+### MediaWiki Compatibility
+- Generate valid MediaWiki markup
+- Support OSRS Wiki specific templates and conventions
+- Handle MediaWiki escaping and special characters
+- Follow MediaWiki formatting standards
+
+## Error Handling
+
+- Use TypeScript types to prevent common errors
+- Validate inputs where appropriate
+- Provide meaningful error messages
+- Handle null/undefined content gracefully (filter in `addContents`)
+
+## Performance Considerations
+
+- Minimize object creation in `build()` methods
+- Use efficient string concatenation
+- Cache expensive operations when possible
+- Keep transformer operations lightweight
+
+## Version Management
+
+- Follow semantic versioning (semver)
+- Create changesets for all user-facing changes
+- Use `patch` for bug fixes, `minor` for new features, `major` for breaking changes
+- Always include changeset files in pull requests
+
+## OSRS Wiki Integration
+
+This library is specifically designed for OSRS Wiki content generation:
+- Support common OSRS Wiki templates
+- Handle game-specific content types
+- Generate markup compatible with MediaWiki installations
+- Consider OSRS Wiki naming conventions and standards
+
+Remember: This is a foundational library used by other OSRS Wiki tools. Maintain backward compatibility, ensure comprehensive testing, and prioritize developer experience through clear APIs and good TypeScript support.

--- a/src/builder/content/MediaWikiContent.utils.test.ts
+++ b/src/builder/content/MediaWikiContent.utils.test.ts
@@ -21,4 +21,72 @@ describe("MediaWikiContent utils", () => {
       buildContents([new MediaWikiContentTest(), new MediaWikiContentTest()])
     ).toBe("testtest");
   });
+
+  test("buildContents filters out undefined elements", () => {
+    // Test the safety filter by creating an array with undefined elements
+    const contentArray = [
+      new MediaWikiContentTest(),
+      undefined,
+      new MediaWikiContentTest(),
+    ] as (MediaWikiContentTest | undefined)[];
+
+    expect(buildContents(contentArray as MediaWikiContent[])).toBe("testtest");
+  });
+
+  test("buildContents filters out null elements", () => {
+    // Test the safety filter by creating an array with null elements
+    const contentArray = [
+      new MediaWikiContentTest(),
+      null,
+      new MediaWikiContentTest(),
+    ] as (MediaWikiContentTest | null)[];
+
+    expect(buildContents(contentArray as MediaWikiContent[])).toBe("testtest");
+  });
+
+  test("buildContents filters out objects without build method", () => {
+    // Test the safety filter by creating an array with invalid objects
+    const invalidObject = { notABuildMethod: () => "should not appear" };
+    const contentArray = [
+      new MediaWikiContentTest(),
+      invalidObject,
+      new MediaWikiContentTest(),
+    ] as (MediaWikiContentTest | typeof invalidObject)[];
+
+    expect(buildContents(contentArray as MediaWikiContent[])).toBe("testtest");
+  });
+
+  test("buildContents handles array with all invalid elements", () => {
+    // Test with array containing only invalid elements
+    const invalidArray = [undefined, null, {}] as (undefined | null | object)[];
+    expect(buildContents(invalidArray as MediaWikiContent[])).toBe("");
+  });
+
+  test("buildContents handles empty array", () => {
+    expect(buildContents([])).toBe("");
+  });
+
+  test("buildContents handles mixed valid and invalid elements", () => {
+    const validElement1 = new MediaWikiContentTest();
+    const validElement2 = new MediaWikiContentTest();
+    const invalidObject = { someProperty: "value" };
+    const invalidBuildObject = { build: "not a function" };
+
+    const mixedArray = [
+      validElement1,
+      undefined,
+      null,
+      invalidObject,
+      validElement2,
+      invalidBuildObject,
+    ] as (
+      | MediaWikiContentTest
+      | undefined
+      | null
+      | typeof invalidObject
+      | typeof invalidBuildObject
+    )[];
+
+    expect(buildContents(mixedArray as MediaWikiContent[])).toBe("testtest");
+  });
 });

--- a/src/builder/content/MediaWikiContent.utils.ts
+++ b/src/builder/content/MediaWikiContent.utils.ts
@@ -10,6 +10,10 @@ export const buildContents = (contents: string | MediaWikiContents): string => {
     return contents;
   }
   return Array.isArray(contents)
-    ? contents.reduce((value, content) => (value += content.build()), "")
+    ? contents
+        .filter(
+          (content) => content != null && typeof content.build === "function"
+        )
+        .reduce((value, content) => (value += content.build()), "")
     : contents.build();
 };


### PR DESCRIPTION
This pull request addresses a bug in the `buildContents` function of the MediaWiki builder library, ensuring that undefined, null, or invalid elements in content arrays do not cause runtime errors. It also adds comprehensive tests for this edge case and updates documentation for project guidelines.

Bug fix and content safety:

* Updated `buildContents` in `src/builder/content/MediaWikiContent.utils.ts` to filter out undefined, null, and objects lacking a valid `build` method before building content arrays, preventing TypeErrors during build operations. [[1]](diffhunk://#diff-bfd1170ce0fd17962db578e1250b8fd76d1a8e8acc8b2f703b3f7c3aeef991edL13-R17) [[2]](diffhunk://#diff-145c55b4149df6609a7097673629699329df791ed8b8ea09bc5d71259b3021d0R1-R5)

Testing improvements:

* Added multiple unit tests in `src/builder/content/MediaWikiContent.utils.test.ts` to verify that `buildContents` correctly filters invalid elements, including undefined, null, objects without a `build` method, and mixed arrays, ensuring robust error handling.

Documentation:

* Added a new `.github/copilot-instructions.md` file detailing code style, architecture, content type implementation, testing guidelines, and API principles for contributors and Copilot usage.